### PR TITLE
fix: wait for the delayed login alerts and elements

### DIFF
--- a/badminton_bot/services/sports_center_webservice.py
+++ b/badminton_bot/services/sports_center_webservice.py
@@ -2,12 +2,17 @@
 
 import logging
 from abc import ABC, abstractmethod
+from typing import Callable
 
 import aiohttp
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
+
+# 登入頁的提醒視窗與元素都是延遲出現的。登入本身在開搶前三分鐘執行，等久一點不影響搶場地
+LOGIN_WAIT_SECONDS = 10
 
 
 class SportsCenterWebService(ABC):
@@ -86,17 +91,21 @@ class SportsCenterWebService(ABC):
 
             return
 
-        wait = WebDriverWait(self._driver, timeout=2)
-        alert = wait.until(lambda d: d.switch_to.alert)
-        logging.debug("第一個彈出視窗訊息： %s", alert.text)
-        alert.accept()
+        # 兩個提醒視窗是頁面載入完才跳出來的（實測約 0.5 ~ 1 秒），所以要輪詢等待。
+        # 不能用 lambda d: d.switch_to.alert，WebDriverWait 預設只忽略 NoSuchElementException，
+        # alert 還沒跳出時丟的 NoAlertPresentException 會直接往外拋，等於只看了一次就放棄。
+        for order in ("第一", "第二"):
+            alert = WebDriverWait(self._driver, timeout=LOGIN_WAIT_SECONDS).until(
+                expected_conditions.alert_is_present()
+            )
+            logging.debug("%s個彈出視窗訊息： %s", order, alert.text)
+            alert.accept()
 
-        wait = WebDriverWait(self._driver, timeout=2)
-        alert = wait.until(lambda d: d.switch_to.alert)
-        logging.debug("第二個彈出視窗訊息： %s", alert.text)
-        alert.accept()
-
-        checkbox = self._find_checkbox_element()
+        # 詐騙提醒的 SweetAlert2 視窗是兩個 alert 關掉之後才渲染出來的（實測只差約 50 毫秒），
+        # find_element 沒有隱含等待，立刻找會 NoSuchElementException
+        checkbox = self._wait_for_element(
+            self._find_checkbox_element, require_displayed=True
+        )
         checkbox.click()
 
         logging.info("登入中...")
@@ -108,13 +117,44 @@ class SportsCenterWebService(ABC):
         try:
             self._driver.execute_script("DoSubmit()")
 
-            welcome_message = self._get_login_user_name_from_website()
+            # DoSubmit() 會重新導向頁面，歡迎訊息不會馬上出現在 DOM 裡，
+            # 不等的話會誤判成登入失敗
+            welcome_message = self._wait_for_element(
+                self._get_login_user_name_from_website
+            )
             self.__is_login = True
             logging.info("%s 登入成功!", welcome_message.text)
         except Exception:
             login_fail_element = self._get_login_failed_message()
             logging.error("%s", login_fail_element.text)
             self.__is_login = False
+
+    def _wait_for_element(
+        self,
+        find_element_func: Callable[[], WebElement],
+        require_displayed: bool = False,
+    ) -> WebElement:
+        """輪詢等待延遲渲染的元素出現後回傳
+
+        WebDriverWait 預設就會忽略 NoSuchElementException，所以元素還沒渲染出來時會繼續等。
+
+        Args:
+            find_element_func (Callable[[], WebElement]): 回傳目標元素的函式
+            require_displayed (bool, optional): 是否要等到元素可見（要點擊的元素才需要）。
+                Defaults to False.
+
+        Returns:
+            WebElement: 已經出現的目標元素
+        """
+
+        def _found(driver) -> WebElement | bool:
+            element = find_element_func()
+            if require_displayed and not element.is_displayed():
+                return False
+
+            return element
+
+        return WebDriverWait(self._driver, timeout=LOGIN_WAIT_SECONDS).until(_found)
 
     @abstractmethod
     def _get_login_user_name_from_website(self) -> str:

--- a/tests/test_sports_center_webservice.py
+++ b/tests/test_sports_center_webservice.py
@@ -6,7 +6,10 @@ suite from touching the live booking sites. Only the pure parts (URL building,
 response parsing, subclass contract) are exercised.
 """
 
+from unittest.mock import Mock
+
 import pytest
+from selenium.common.exceptions import NoAlertPresentException, NoSuchElementException
 
 from badminton_bot.services.sports_center_webservice import SportsCenterWebService
 from badminton_bot.services.zhongshan_sports_center_webservice import (
@@ -101,3 +104,161 @@ class TestIsBookingSuccess:
         """The failure branch is checked first, so a page containing both is a failure."""
         service = build_without_browser(service_cls)
         assert service._is_booking_success(text="PT=1&X=2 ... PT=1&X=1") is False
+
+
+class _FakeElement:
+    """A page element that records whether it was clicked / typed into."""
+
+    def __init__(self, text: str = "測試使用者") -> None:
+        self.text = text
+        self.clicked = False
+        self.keys: list[str] = []
+
+    def is_displayed(self) -> bool:
+        return True
+
+    def click(self) -> None:
+        self.clicked = True
+
+    def send_keys(self, value: str) -> None:
+        self.keys.append(value)
+
+
+class _FakeAlert:
+    """A native JS alert that records whether it was accepted."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.accepted = False
+
+    def accept(self) -> None:
+        self.accepted = True
+
+
+class _FakeSwitchTo:
+    def __init__(self, driver: "_FakeDriver") -> None:
+        self._driver = driver
+
+    @property
+    def alert(self) -> _FakeAlert:
+        return self._driver._poll_for_alert()
+
+
+class _FakeDriver:
+    """Driver whose alerts only show up after a few polls.
+
+    登入頁的兩個 alert 是網頁載入後才跳出來的（實測約 0.5 ~ 0.9 秒），
+    所以 driver.get() 回來的當下還沒有 alert 可以切換。
+    """
+
+    def __init__(
+        self,
+        alert_texts: tuple[str, ...],
+        polls_before_each_alert: int = 1,
+        delayed_selectors: dict[str, int] | None = None,
+    ) -> None:
+        self.alerts = [_FakeAlert(text) for text in alert_texts]
+        self._polls_before_each_alert = polls_before_each_alert
+        self._polls = 0
+        self.switch_to = _FakeSwitchTo(self)
+        self.executed_scripts: list[str] = []
+        # {selector: 還要再被找幾次才會出現}，用來模擬延遲渲染的元素
+        self._delayed_selectors = dict(delayed_selectors or {})
+        self.elements: dict[str, _FakeElement] = {}
+
+    def _poll_for_alert(self) -> _FakeAlert:
+        pending = [alert for alert in self.alerts if not alert.accepted]
+        if not pending:
+            raise NoAlertPresentException("no such alert")
+
+        self._polls += 1
+        if self._polls <= self._polls_before_each_alert:
+            raise NoAlertPresentException("no such alert")
+
+        self._polls = 0
+        return pending[0]
+
+    def find_element(self, by, value):
+        remaining = self._delayed_selectors.get(value, 0)
+        if remaining > 0:
+            self._delayed_selectors[value] = remaining - 1
+            raise NoSuchElementException(f"no such element: {value}")
+
+        return self.elements.setdefault(value, _FakeElement())
+
+    def quit(self):
+        pass
+
+    def execute_script(self, script, *args):
+        self.executed_scripts.append(script)
+
+
+class TestLoginWaitsForTheAlerts:
+    """登入頁的 alert 是延遲跳出的，login() 必須真的輪詢等待，不能只看一次。"""
+
+    @staticmethod
+    def _build(service_cls, **kwargs):
+        service = build_without_browser(service_cls)
+        service._driver = _FakeDriver(
+            alert_texts=("這只是提醒！！！", "報名運動課程請使用個人帳密報名繳費"), **kwargs
+        )
+        service._SportsCenterWebService__is_login = False
+        service._SportsCenterWebService__username = "A123456789"
+        service._SportsCenterWebService__password = "secret"
+        return service
+
+    @pytest.mark.parametrize("service_cls", SERVICE_CLASSES)
+    def test_login_accepts_both_delayed_alerts(self, service_cls):
+        service = self._build(service_cls)
+
+        service.login()
+
+        assert [alert.accepted for alert in service._driver.alerts] == [True, True]
+        assert service.login_status is True
+        assert "DoSubmit()" in service._driver.executed_scripts
+
+    @pytest.mark.parametrize("service_cls", SERVICE_CLASSES)
+    def test_login_still_works_when_the_alert_is_slow(self, service_cls):
+        """就算 alert 慢了好幾次輪詢才出現，也要等到它。"""
+        service = self._build(service_cls, polls_before_each_alert=4)
+
+        service.login()
+
+        assert [alert.accepted for alert in service._driver.alerts] == [True, True]
+        assert service.login_status is True
+
+
+class TestLoginWaitsForDelayedElements:
+    """兩個 alert 關掉之後才渲染出來的元素，也必須等，不能立刻就找。"""
+
+    @staticmethod
+    def _build(service_cls, delayed_selectors):
+        service = build_without_browser(service_cls)
+        service._driver = _FakeDriver(
+            alert_texts=("這只是提醒！！！", "報名運動課程請使用個人帳密報名繳費"),
+            delayed_selectors=delayed_selectors,
+        )
+        service._SportsCenterWebService__is_login = False
+        service._SportsCenterWebService__username = "A123456789"
+        service._SportsCenterWebService__password = "secret"
+        return service
+
+    @pytest.mark.parametrize("service_cls", SERVICE_CLASSES)
+    def test_login_waits_for_the_delayed_confirm_popup(self, service_cls):
+        """詐騙提醒的 SweetAlert2 視窗在 alert 關掉後才出現（實測差約 50 毫秒）。"""
+        service = self._build(service_cls, {"swal2-actions": 3})
+
+        service.login()
+
+        assert service._driver.elements["swal2-actions"].clicked is True
+        assert service.login_status is True
+
+    @pytest.mark.parametrize("service_cls", SERVICE_CLASSES)
+    def test_login_waits_for_the_welcome_message_after_submit(self, service_cls):
+        """DoSubmit() 之後頁面要重新導向，歡迎訊息不會馬上就在 DOM 裡。"""
+        service = self._build(service_cls, {"//span[@id='lab_Name']": 3})
+
+        service.login()
+
+        assert service.login_status is True
+        assert "DoSubmit()" in service._driver.executed_scripts


### PR DESCRIPTION
## 問題

實際跑 `python -m badminton_bot.main` 搶中正運動中心的場地時，登入階段直接中斷：

```
NoAlertPresentException: Message: no such alert
  File "badminton_bot/services/sports_center_webservice.py", line 90, in login
    alert = wait.until(lambda d: d.switch_to.alert)
```

## 根因

`wait.until(lambda d: d.switch_to.alert)` **其實不會重試**。`WebDriverWait` 預設的
`ignored_exceptions` 只有 `NoSuchElementException`，而 alert 還沒跳出來時丟的是
`NoAlertPresentException`（兩者沒有繼承關係），會直接往外拋。也就是說 `timeout=2`
從來沒有生效過，等於只看了一次就放棄。

實際量測登入頁：alert 是頁面載入後才跳出來的，而且時間會浮動 —— 兩次量到 0.5s 和 0.92s。
所以這一直是個 race，只是以前頁面載入比較慢時剛好會中。

同一類問題另外兩處（都是「沒等延遲出現的東西」）：

| 位置 | 現象 |
|---|---|
| `swal2-actions`（詐騙提醒視窗） | 兩個 alert 關掉後才渲染，實測只差約 50 毫秒，`find_element` 沒有隱含等待，立刻找會 `NoSuchElementException` |
| `lab_Name`（歡迎訊息） | `DoSubmit()` 重新導向後才出現，沒等的話會被 `except` 接住，把**成功的登入誤判成登入失敗** |

## 修正

- 用 `expected_conditions.alert_is_present()` 等 alert（它會把 `NoAlertPresentException`
  吃掉並回傳 `False`，所以輪詢才會真的成立）。
- 新增 `_wait_for_element()` 輪詢等待延遲渲染的元素，`require_displayed` 給需要點擊的元素用。
- 兩個 alert 的處理合併成迴圈，少掉一段複製貼上。

登入是在開搶前三分鐘執行的，所以把等待拉到 10 秒不會影響搶場地的時機。

## 測試

新增 8 個測試（4 個情境 × 2 個運動中心），用假的 driver 模擬「元素延遲出現」，
**不會連到線上網站**，符合 CLAUDE.md 的 live-site 限制。

已確認這些測試在還原修正後會失敗（8 failed），修正後才會過 —— 不是空測試。

```
64 passed
```

## 線上驗證

修正後實際完整跑過一次，整條流程都正常：

```
17:41:15  開啟 Chrome 瀏覽器          <- 開搶前 3 分鐘登入
17:41:21  廖○為 您好| 登入成功!
17:44:15.000  搶 2026/8/24 6 ~ 7 的場地   <- 準時發出
17:44:17  2026/8/24 6 ~ 7 的場地預約失敗
17:44:18  登出成功                     exit code 0
```

該時段回傳 `PT=1&X=2`（預約失敗），另外用唯讀方式查了當天的場地表確認過，
這是**正確的結果**：8/24 早上 54 個格子有 50 個已被預約，06:00 只剩
羽球7-1 / 羽球7-2 是空的，而程式寫死的 `QPid=1199` 不在其中。

順帶確認 `QTime` 不補零是對的 —— 網站自己產生的呼叫就是 `Step3Action(1196, 6)`。